### PR TITLE
docs: update README badges and clarify zero configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@
     <a href="https://marketplace.visualstudio.com/items?itemName=async3619.vscode-semantic-imports">
         <img alt="Visual Studio Marketplace Version" src="https://img.shields.io/visual-studio-marketplace/v/async3619.vscode-semantic-imports?style=flat-square&label=marketplace" />
     </a>
-    <a href="https://marketplace.visualstudio.com/items?itemName=async3619.vscode-semantic-imports">
-        <img alt="Visual Studio Marketplace Installs" src="https://img.shields.io/visual-studio-marketplace/i/async3619.vscode-semantic-imports?style=flat-square" />
-    </a>
     <a href="https://github.com/async3619/vscode-semantic-imports/blob/main/LICENSE">
         <img alt="License" src="https://img.shields.io/github/license/async3619/vscode-semantic-imports?style=flat-square" />
+    </a>
+    <a href="https://codecov.io/gh/async3619/vscode-semantic-imports">
+        <img alt="Codecov" src="https://img.shields.io/codecov/c/github/async3619/vscode-semantic-imports?style=flat-square" />
     </a>
     <br />
     <sup>Accurate syntax highlighting for imported symbols in TypeScript</sup>


### PR DESCRIPTION
## Summary

- Zero configuration 설명을 구체화: 활성 테마에서 자동으로 색상을 추출하고, semantic token colors / TextMate rules를 모두 지원하며, 사용자 커스텀 색상 설정도 반영한다는 점을 명시
- Installation count 뱃지 제거, Codecov coverage 뱃지 추가

## Changes

- `README.md`: Zero configuration 항목에 테마 기반 색상 추출 동작 설명 추가
- `README.md`: Marketplace installs 뱃지 제거, Codecov 뱃지 추가