### PR TITLE
ci: add marketplace publish workflow on tag creation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -24,10 +27,9 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
+          pnpm package
           if [[ "${{ github.ref_name }}" == *-* ]]; then
-            pnpm package
-            vsce publish --no-dependencies --packagePath *.vsix --pre-release
+            pnpm exec vsce publish --no-dependencies --packagePath *.vsix --pre-release
           else
-            pnpm package
-            vsce publish --no-dependencies --packagePath *.vsix
+            pnpm exec vsce publish --no-dependencies --packagePath *.vsix
           fi


### PR DESCRIPTION
## 요약

tag 생성 시 VS Code Marketplace에 자동으로 extension을 publish하는 워크플로우를 추가한다. 현재 CI는 semantic-release를 통해 tag/GitHub Release 생성까지만 수행하고, 실제 Marketplace 업로드는 누락되어 있었다.

## 변경 사항

- `v*` 태그 push 이벤트에 트리거되는 `.github/workflows/publish.yml` 워크플로우 추가
- tag에 `-`가 포함되면 `--pre-release` 플래그로 pre-release 버전 게시 (예: `v1.0.0-dev.5`)
- stable tag는 정식 버전으로 게시 (예: `v1.0.0`)
- 인증은 `VSCE_PAT` repository secret 사용

## 사전 준비

- Repository Settings > Secrets에 `VSCE_PAT` (Azure DevOps Personal Access Token) 등록 필요

Closes #27