### PR TITLE
feat(resolver): detect function types in const/let/var declarations

### DIFF
--- a/src/symbol/resolvers/hover.test.ts
+++ b/src/symbol/resolvers/hover.test.ts
@@ -3,6 +3,12 @@ import * as vscode from 'vscode'
 import { TsServerLoadingError } from '../errors'
 import { HoverSymbolResolver } from './hover'
 import { SymbolKind } from '../types'
+import { loadTypeScript } from '../utils/loadTypeScript'
+
+vi.mock('../utils/loadTypeScript', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  loadTypeScript: vi.fn(() => require('typescript')),
+}))
 
 type ResolverInternals = {
   output: vscode.OutputChannel
@@ -140,6 +146,96 @@ describe('HoverSymbolResolver', () => {
     vi.mocked(vscode.commands.executeCommand).mockResolvedValue([{ contents: ['(alias) const X: number'] }])
     const result = await resolver.resolve(createMockDocument(), createMockPosition())
     expect(result).toBe(SymbolKind.Variable)
+  })
+
+  describe('const function type detection', () => {
+    const functionTypes: Array<[string, string]> = [
+      ['() => void', 'arrow function'],
+      ['(x: string) => number', 'arrow function with params'],
+      ['<T>(arg: T) => T', 'generic arrow function'],
+      ['() => Promise<void>', 'async arrow function'],
+      ['new () => Foo', 'constructor type'],
+      ['{ (): void }', 'callable object'],
+    ]
+
+    for (const [typeText, description] of functionTypes) {
+      it(`should resolve const with ${description} type to Function: "${typeText}"`, async () => {
+        vi.mocked(vscode.commands.executeCommand).mockResolvedValue([
+          { contents: [new vscode.MarkdownString(`(alias) const foo: ${typeText}`)] },
+        ])
+        const result = await resolver.resolve(createMockDocument(), createMockPosition())
+        expect(result).toBe(SymbolKind.Function)
+      })
+    }
+
+    it('should resolve let with function type to Function', async () => {
+      vi.mocked(vscode.commands.executeCommand).mockResolvedValue([
+        { contents: [new vscode.MarkdownString('(alias) let handler: () => void')] },
+      ])
+      const result = await resolver.resolve(createMockDocument(), createMockPosition())
+      expect(result).toBe(SymbolKind.Function)
+    })
+
+    it('should resolve var with function type to Function', async () => {
+      vi.mocked(vscode.commands.executeCommand).mockResolvedValue([
+        { contents: [new vscode.MarkdownString('(alias) var handler: () => void')] },
+      ])
+      const result = await resolver.resolve(createMockDocument(), createMockPosition())
+      expect(result).toBe(SymbolKind.Function)
+    })
+
+    const nonFunctionTypes: Array<[string, string]> = [
+      ['number', 'primitive'],
+      ['string[]', 'array'],
+      ['{ bar: number }', 'object literal'],
+      ['42', 'literal type'],
+    ]
+
+    for (const [typeText, description] of nonFunctionTypes) {
+      it(`should resolve const with ${description} type to Variable: "${typeText}"`, async () => {
+        vi.mocked(vscode.commands.executeCommand).mockResolvedValue([
+          { contents: [new vscode.MarkdownString(`(alias) const foo: ${typeText}`)] },
+        ])
+        const result = await resolver.resolve(createMockDocument(), createMockPosition())
+        expect(result).toBe(SymbolKind.Variable)
+      })
+    }
+
+    it('should return undefined for type alias (fallback to next resolver)', async () => {
+      vi.mocked(vscode.commands.executeCommand).mockResolvedValue([
+        { contents: [new vscode.MarkdownString('(alias) const handler: MyCallback')] },
+      ])
+      const result = await resolver.resolve(createMockDocument(), createMockPosition())
+      expect(result).toBeUndefined()
+    })
+
+    it('should return undefined for typeof (fallback to next resolver)', async () => {
+      vi.mocked(vscode.commands.executeCommand).mockResolvedValue([
+        { contents: [new vscode.MarkdownString('(alias) const foo: typeof someFunc')] },
+      ])
+      const result = await resolver.resolve(createMockDocument(), createMockPosition())
+      expect(result).toBeUndefined()
+    })
+
+    it('should return Variable when const has no type annotation', async () => {
+      vi.mocked(vscode.commands.executeCommand).mockResolvedValue([
+        { contents: [new vscode.MarkdownString('(alias) const FOO')] },
+      ])
+      const result = await resolver.resolve(createMockDocument(), createMockPosition())
+      expect(result).toBe(SymbolKind.Variable)
+    })
+  })
+
+  describe('const function detection when TypeScript is unavailable', () => {
+    it('should return undefined when loadTypeScript returns undefined', async () => {
+      vi.mocked(loadTypeScript).mockReturnValueOnce(undefined as never)
+
+      vi.mocked(vscode.commands.executeCommand).mockResolvedValue([
+        { contents: [new vscode.MarkdownString('(alias) const foo: () => void')] },
+      ])
+      const result = await resolver.resolve(createMockDocument(), createMockPosition())
+      expect(result).toBeUndefined()
+    })
   })
 
   describe('tsserver loading detection', () => {

--- a/src/symbol/utils/isFunctionType.test.ts
+++ b/src/symbol/utils/isFunctionType.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import ts from 'typescript'
+import { isFunctionType } from './isFunctionType'
+
+describe('isFunctionType', () => {
+  describe('function types → true', () => {
+    const cases = [
+      '() => void',
+      '(x: string) => number',
+      '(a: number, b: string) => boolean',
+      '() => Promise<void>',
+      '<T>(arg: T) => T',
+      '<T, U>(a: T, b: U) => [T, U]',
+      'new () => Foo',
+      'new (x: string) => Bar',
+      '(x: { nested: () => void }) => number',
+    ]
+
+    for (const typeText of cases) {
+      it(`should return true for "${typeText}"`, () => {
+        expect(isFunctionType(ts, typeText)).toBe(true)
+      })
+    }
+  })
+
+  describe('callable object types → true', () => {
+    const cases = ['{ (): void }', '{ new (): Foo }', '{ (): void; name: string }']
+
+    for (const typeText of cases) {
+      it(`should return true for "${typeText}"`, () => {
+        expect(isFunctionType(ts, typeText)).toBe(true)
+      })
+    }
+  })
+
+  describe('parenthesized function types → true', () => {
+    it('should return true for "(() => void)"', () => {
+      expect(isFunctionType(ts, '(() => void)')).toBe(true)
+    })
+  })
+
+  describe('non-function types → false', () => {
+    const cases = [
+      'string',
+      'number',
+      'boolean',
+      'void',
+      'null',
+      'undefined',
+      'never',
+      'unknown',
+      'any',
+      '42',
+      '"hello"',
+      'true',
+      'string[]',
+      '[string, number]',
+      'string | number',
+      'string & { brand: true }',
+      '{ bar: number }',
+      '{ name: string; age: number }',
+    ]
+
+    for (const typeText of cases) {
+      it(`should return false for "${typeText}"`, () => {
+        expect(isFunctionType(ts, typeText)).toBe(false)
+      })
+    }
+  })
+
+  describe('ambiguous types → undefined', () => {
+    const cases = ['MyCallback', 'React.FC', 'Record<string, number>', 'typeof someFunction', 'typeof import("react")']
+
+    for (const typeText of cases) {
+      it(`should return undefined for "${typeText}"`, () => {
+        expect(isFunctionType(ts, typeText)).toBeUndefined()
+      })
+    }
+  })
+
+  describe('edge cases', () => {
+    it('should return undefined for empty string', () => {
+      expect(isFunctionType(ts, '')).toBeUndefined()
+    })
+
+    it('should return false for object type without call signatures', () => {
+      expect(isFunctionType(ts, '{ handler: () => void }')).toBe(false)
+    })
+  })
+})

--- a/src/symbol/utils/isFunctionType.ts
+++ b/src/symbol/utils/isFunctionType.ts
@@ -1,0 +1,39 @@
+type TypeScript = typeof import('typescript')
+
+export function isFunctionType(ts: TypeScript, typeText: string): boolean | undefined {
+  const source = `type __t = ${typeText}`
+
+  let sf: import('typescript').SourceFile
+  try {
+    sf = ts.createSourceFile('__check.ts', source, ts.ScriptTarget.Latest, false)
+  } catch {
+    return undefined
+  }
+
+  const stmt = sf.statements[0]
+  if (!stmt || !ts.isTypeAliasDeclaration(stmt)) {
+    return undefined
+  }
+
+  return classifyTypeNode(ts, stmt.type)
+}
+
+function classifyTypeNode(ts: TypeScript, node: import('typescript').TypeNode): boolean | undefined {
+  if (ts.isFunctionTypeNode(node) || ts.isConstructorTypeNode(node)) {
+    return true
+  }
+
+  if (ts.isTypeLiteralNode(node)) {
+    return node.members.some((m) => ts.isCallSignatureDeclaration(m) || ts.isConstructSignatureDeclaration(m))
+  }
+
+  if (ts.isTypeReferenceNode(node) || ts.isTypeQueryNode(node) || ts.isImportTypeNode(node)) {
+    return undefined
+  }
+
+  if (ts.isParenthesizedTypeNode(node)) {
+    return classifyTypeNode(ts, node.type)
+  }
+
+  return false
+}

--- a/src/symbol/utils/loadTypeScript.test.ts
+++ b/src/symbol/utils/loadTypeScript.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import * as vscode from 'vscode'
+import { loadTypeScript, _resetTypeScriptCache } from './loadTypeScript'
+
+describe('loadTypeScript', () => {
+  beforeEach(() => {
+    _resetTypeScriptCache()
+  })
+
+  it('should return undefined when typescript-language-features extension is not found', () => {
+    const result = loadTypeScript()
+    expect(result).toBeUndefined()
+  })
+
+  it('should load TypeScript from extension path when available', () => {
+    const mockGetExtension = vi.fn().mockReturnValue({
+      extensionPath: '/mock/extensions/vscode.typescript-language-features',
+    })
+    vi.mocked(vscode.extensions).getExtension = mockGetExtension
+
+    const result = loadTypeScript()
+
+    expect(mockGetExtension).toHaveBeenCalledWith('vscode.typescript-language-features')
+    // In test environment, require will fail for the mock path
+    // but the function should handle it gracefully
+    expect(result).toBeUndefined()
+  })
+
+  it('should cache the result after first call', () => {
+    loadTypeScript()
+    loadTypeScript()
+
+    // getExtension should only be called once due to caching
+    // (in test env it's undefined, so it returns undefined and caches null)
+    expect(loadTypeScript()).toBeUndefined()
+  })
+
+  it('should return cached value on subsequent calls', () => {
+    _resetTypeScriptCache()
+
+    const first = loadTypeScript()
+    const second = loadTypeScript()
+
+    expect(first).toBe(second)
+  })
+})

--- a/src/symbol/utils/loadTypeScript.ts
+++ b/src/symbol/utils/loadTypeScript.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode'
+import * as path from 'path'
+
+type TypeScript = typeof import('typescript')
+
+let cached: TypeScript | null | undefined
+
+export function loadTypeScript(): TypeScript | undefined {
+  if (cached !== undefined) {
+    return cached ?? undefined
+  }
+
+  cached = null
+
+  const tsExt = vscode.extensions.getExtension?.('vscode.typescript-language-features')
+  if (!tsExt) {
+    return undefined
+  }
+
+  try {
+    const tsPath = path.join(path.dirname(tsExt.extensionPath), 'node_modules', 'typescript')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    cached = require(tsPath) as TypeScript
+  } catch {
+    // Failed to load TypeScript from VS Code built-in
+  }
+
+  return cached ?? undefined
+}
+
+export function _resetTypeScriptCache() {
+  cached = undefined
+}


### PR DESCRIPTION
## 요약

`const`/`let`/`var`로 선언된 arrow function, function expression이 `Variable`로 잘못 분류되는 문제를 해결한다. HoverSymbolResolver에서 hover 텍스트의 타입 부분을 TypeScript 파서(`ts.createSourceFile`)로 분석하여 함수 타입 여부를 정확하게 판별한다.

Closes #29

## 변경 사항

- **`loadTypeScript.ts`**: VS Code 내장 TypeScript를 런타임에 lazy-load하는 유틸리티 추가. 번들 사이즈 영향 없음 (동적 require)
- **`isFunctionType.ts`**: TypeScript 파서 기반 함수 타입 판별 순수 함수 추가
  - `FunctionTypeNode`, `ConstructorTypeNode`, callable `TypeLiteralNode` → `true`
  - `TypeReference`, `TypeQuery`, `ImportType` → `undefined` (SemanticTokenResolver로 위임)
  - 그 외 모든 타입 → `false`
- **`hover.ts`**: `const`/`let`/`var` 감지 시 타입 분석 → 함수면 `Function`, 아니면 `Variable`, 판별 불가 시 다음 resolver로 위임
- 테스트 56개 추가 (isFunctionType 38개, loadTypeScript 4개, hover resolver 14개)
