### PR TITLE
fix(ci): trigger publish workflow on release event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
## 요약

GitHub Release로 태그를 생성하면 `push` 이벤트가 아닌 `release` 이벤트가 발생하여 publish 워크플로우가 트리거되지 않는 문제를 수정합니다.

## 변경 사항

- 워크플로우 트리거를 `push: tags: ['v*']`에서 `release: types: [published]`로 변경

Closes #