### PR TITLE
fix(ci): pass pre-release flag during vsce package step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,9 +26,11 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
-          pnpm package
+          pnpm run build
           if [[ "${{ github.ref_name }}" == *-* ]]; then
+            pnpm exec vsce package --no-dependencies --pre-release
             pnpm exec vsce publish --no-dependencies --packagePath *.vsix --pre-release
           else
+            pnpm exec vsce package --no-dependencies
             pnpm exec vsce publish --no-dependencies --packagePath *.vsix
           fi


### PR DESCRIPTION
## 요약

pre-release 버전 퍼블리시 시 `vsce package` 단계에서 `--pre-release` 플래그 없이 패키징되어 `vsce publish --pre-release`가 실패하는 문제를 수정합니다.

## 변경 사항

- `pnpm package` 대신 `pnpm run build` 후 분기별로 `vsce package`를 실행하여 pre-release 패키징과 일반 패키징을 구분