### PR TITLE
fix(ci): convert pre-release version to marketplace-compatible format

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,14 @@ jobs:
         run: |
           pnpm run build
           if [[ "${{ github.ref_name }}" == *-* ]]; then
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#v}"
+            BASE="${VERSION%%-*}"
+            MAJOR=$(echo "$BASE" | cut -d. -f1)
+            MINOR=$(echo "$BASE" | cut -d. -f2)
+            DEV_NUM="${VERSION##*.}"
+            if (( MINOR % 2 == 0 )); then MINOR=$((MINOR + 1)); fi
+            npm version "$MAJOR.$MINOR.$DEV_NUM" --no-git-tag-version
             pnpm exec vsce package --no-dependencies --pre-release
             pnpm exec vsce publish --no-dependencies --packagePath *.vsix --pre-release
           else


### PR DESCRIPTION
## 요약

VS Marketplace가 `1.0.0-dev.8` 같은 semver pre-release 식별자를 지원하지 않아 퍼블리시가 실패하는 문제를 수정합니다. VS Code 권장 컨벤션에 따라 홀수 minor 버전으로 변환합니다.

## 변경 사항

- pre-release 퍼블리시 시 태그에서 버전을 추출하여 marketplace 호환 형식으로 변환
  - 예: `v1.0.0-dev.8` → `1.1.8` (홀수 minor = pre-release)
- `npm version --no-git-tag-version`으로 package.json을 CI 내에서만 임시 수정