### PR TITLE
fix(ci): build vsix for pre-release versions

### DIFF
--- a/scripts/vsce-package.sh
+++ b/scripts/vsce-package.sh
@@ -3,9 +3,6 @@ set -euo pipefail
 
 VERSION="$1"
 
-# Skip marketplace packaging for pre-release versions
-if [[ "$VERSION" == *-* ]]; then exit 0; fi
-
 vsce package --no-dependencies
 
 # vsce hardcodes node_modules/** exclusion (microsoft/vscode-vsce#970).


### PR DESCRIPTION
## 요약

pre-release 빌드에서 `.vsix` 파일이 생성되지 않아 GitHub Release에 업로드되지 않던 문제를 수정한다. `vsce-package.sh`의 pre-release early exit를 제거하여 `.vsix`를 항상 빌드하도록 변경.

## 변경 사항

- `scripts/vsce-package.sh`에서 pre-release 버전 체크 및 early exit 제거
- marketplace publish 스킵은 `vsce-publish.sh`에서 이미 처리하므로 영향 없음

Closes #37