### PR TITLE
docs: add before/after comparison and highlight speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,17 @@
 
 ## Introduction
 
+|             Before             |            After             |
+| :----------------------------: | :--------------------------: |
+| ![Before](./assets/before.png) | ![After](./assets/after.png) |
+
 VS Code's built-in syntax highlighting treats all identifiers the same way, regardless of whether they are locally defined or imported from external modules. This extension solves this by analyzing import statements and applying precise, type-aware coloring to every usage of imported symbols throughout your file.
 
 This means you can visually distinguish imported functions, classes, types, and variables at a glance — making your code easier to read and navigate.
 
 ## Features
 
+- **Fast** — Resolves symbol types through a TypeScript Server plugin running inside tsserver, avoiding expensive external API calls
 - **Type-aware coloring** — Imported symbols are colored based on their resolved type (function, class, interface, etc.), not just their text
 - **Zero configuration** — Automatically reads your active color theme and applies matching colors to imported symbols. Supports both semantic token colors and TextMate rules, and also respects your custom color settings (`editor.semanticTokenColorCustomizations`, `editor.tokenColorCustomizations`). When you switch themes, colors update instantly — no settings to configure
 


### PR DESCRIPTION
## 요약

README에 Before/After 비교 테이블과 속도 특장점(tsserver 플러그인 기반 빠른 심볼 해석)을 추가한다.

## 변경 사항

- Introduction 섹션에 Before/After 이미지 비교 테이블 추가
- Features에 **Fast** 항목 추가