### PR TITLE
fix: restrict extension to workspace-only environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Press `F5` in VS Code to launch the Extension Development Host with the extensio
 - VS Code `1.85.0` or later
 - TypeScript language features enabled (built-in with VS Code)
 
+> [!WARNING]
+> This extension does not support VS Code Web environments (e.g., vscode.dev, github.dev). It requires a local or remote workspace with access to the TypeScript Server.
+
 ## License
 
 MIT &copy; [async3619](https://github.com/async3619)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "engines": {
     "vscode": "^1.85.0"
   },
+  "extensionKind": [
+    "workspace"
+  ],
   "categories": [
     "Programming Languages"
   ],


### PR DESCRIPTION
## 요약

VS Code Web 환경(vscode.dev, github.dev)에서 익스텐션이 로드되지 않도록 `extensionKind`를 `["workspace"]`로 제한하고, README에 미지원 안내를 추가한다.

## 변경 사항

- `package.json`에 `"extensionKind": ["workspace"]` 추가
- `README.md` Requirements 섹션에 VS Code Web 미지원 warning callout 추가

Closes #44