### PR TITLE
fix: exclude codecov binary and unnecessary files from vsix bundle

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -15,3 +15,10 @@ eslint.config.mjs
 .prettierrc
 **/*.test.ts
 **/*.map
+codecov*
+pnpm-lock.yaml
+pnpm-workspace.yaml
+.releaserc.json
+.github/**
+scripts/**
+.claude/**


### PR DESCRIPTION
## 요약

CI에서 `codecov/codecov-action@v5`가 다운로드하는 codecov CLI 바이너리(~11MB)가 `.vscodeignore`에 제외되지 않아 VSIX 번들에 포함되던 문제를 수정한다. 이로 인해 확장 패키지 크기가 12.6MB에서 1.44MB로 감소한다.

## 변경 사항

`.vscodeignore`에 다음 항목을 추가하여 불필요한 파일을 번들에서 제외:

- `codecov*` — codecov CLI 바이너리 및 체크섬 파일
- `pnpm-lock.yaml`, `pnpm-workspace.yaml` — 패키지 매니저 파일
- `.releaserc.json` — semantic-release 설정
- `.github/**` — GitHub Actions 워크플로우
- `scripts/**` — 빌드/배포 스크립트
- `.claude/**` — Claude Code 설정

Closes #47