### PR TITLE
refactor(decoration): decompose DecorationService and simplify data structures (#72)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,7 +23,7 @@ const eslintConfig = defineConfig([
             'src/utils/*.test.ts',
             'src/parser/*.test.ts',
           ],
-          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 20,
+          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 25,
         },
       },
     },

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -68,7 +68,27 @@ class MockUri {
   }
 }
 
+class MockEventEmitter<T> {
+  private listeners: ((e: T) => void)[] = []
+
+  event = (listener: (e: T) => void) => {
+    this.listeners.push(listener)
+    return { dispose: () => this.listeners.splice(this.listeners.indexOf(listener), 1) }
+  }
+
+  fire(data: T) {
+    for (const listener of this.listeners) {
+      listener(data)
+    }
+  }
+
+  dispose() {
+    this.listeners = []
+  }
+}
+
 vi.mock('vscode', () => ({
+  EventEmitter: MockEventEmitter,
   Position: MockPosition,
   Range: MockRange,
   MarkdownString: MockMarkdownString,

--- a/src/decoration/resolver.ts
+++ b/src/decoration/resolver.ts
@@ -1,0 +1,92 @@
+import PQueue from 'p-queue'
+import * as vscode from 'vscode'
+import { Logger } from '../logger'
+import { stopwatch } from '../utils/stopwatch'
+import type { BaseSymbolResolver, SymbolKind } from '../symbol'
+import { HoverSymbolResolver, PluginSymbolResolver, SemanticTokenSymbolResolver } from '../symbol'
+
+const CONCURRENCY_LIMIT = 5
+
+export interface ResolveTarget {
+  source: string
+  range: { start: vscode.Position }
+}
+
+export class SymbolResolver {
+  private readonly logger = Logger.create(SymbolResolver)
+  private readonly resolvers: BaseSymbolResolver[] = [
+    new PluginSymbolResolver(),
+    new HoverSymbolResolver(),
+    new SemanticTokenSymbolResolver(),
+  ]
+  private readonly _onPhase = new vscode.EventEmitter<Map<string, SymbolKind>>()
+  readonly onPhase = this._onPhase.event
+
+  constructor(
+    private readonly document: vscode.TextDocument,
+    private readonly targets: Map<string, ResolveTarget>,
+  ) {}
+
+  async resolve() {
+    const symbolKinds = new Map<string, SymbolKind>()
+
+    for (const resolver of this.resolvers) {
+      const remaining = [...this.targets.keys()].filter((s) => !symbolKinds.has(s))
+      if (remaining.length === 0) {
+        continue
+      }
+
+      const resolved = await this.resolveSymbols(resolver, remaining)
+      for (const [symbol, kind] of resolved) {
+        symbolKinds.set(symbol, kind)
+      }
+
+      if (resolved.size > 0) {
+        this._onPhase.fire(symbolKinds)
+      }
+    }
+
+    this._onPhase.dispose()
+    return symbolKinds
+  }
+
+  private async resolveSymbols(resolver: BaseSymbolResolver, symbols: string[]) {
+    const queue = new PQueue({ concurrency: CONCURRENCY_LIMIT })
+    const promises: Promise<readonly [string, SymbolKind] | undefined | void>[] = []
+    for (const symbol of symbols) {
+      const target = this.targets.get(symbol)
+      if (!target) {
+        continue
+      }
+
+      const label = target.source ? `'${symbol}' from '${target.source}'` : `'${symbol}'`
+
+      const promise = queue.add(() => {
+        return this.resolveSymbol(resolver, symbol, target.range.start, label)
+      })
+
+      promises.push(promise)
+    }
+
+    const results = await Promise.allSettled(promises)
+    return new Map(
+      results
+        .filter(
+          (r): r is PromiseFulfilledResult<readonly [string, SymbolKind]> =>
+            r.status === 'fulfilled' && r.value != null,
+        )
+        .map((r) => r.value),
+    )
+  }
+
+  private async resolveSymbol(resolver: BaseSymbolResolver, symbol: string, position: vscode.Position, label: string) {
+    this.logger.debug(`resolving ${label} via '${resolver.name}' resolver`)
+    const [kind, elapsed] = await stopwatch(() => resolver.resolve(this.document, position))
+    if (!kind) {
+      return
+    }
+
+    this.logger.info(`resolved ${label} → '${kind}' via '${resolver.name}' resolver (in ${elapsed}ms)`)
+    return [symbol, kind] as const
+  }
+}

--- a/src/decoration/service.test.ts
+++ b/src/decoration/service.test.ts
@@ -2,21 +2,18 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as vscode from 'vscode'
 import { DecorationService } from './service'
 import type { DocumentCache } from './types'
-import type { BaseSymbolResolver } from '../symbol'
-import { SymbolKind, TsServerLoadingError } from '../symbol'
+import { SymbolKind } from '../symbol'
+import { HoverSymbolResolver, PluginSymbolResolver, SemanticTokenSymbolResolver } from '../symbol'
 import type { SymbolColorMap } from '../theme'
 import { TypeScriptServerProbe } from '../tsServer'
 import type { ImportStatement } from '../parser'
 import { TypeScriptParser } from '../parser'
 
 type ServiceInternals = {
-  phases: { resolver: BaseSymbolResolver }[]
   probe: TypeScriptServerProbe
   parser: TypeScriptParser
   decorationTypes: Map<string, vscode.TextEditorDecorationType>
   documentCaches: Map<string, DocumentCache>
-  retryTimeouts: Map<string, ReturnType<typeof setTimeout>>
-  probeControllers: Map<string, AbortController>
   colors: SymbolColorMap
   getDecorationType: (color: string) => vscode.TextEditorDecorationType
 }
@@ -64,28 +61,24 @@ function createMockEditor(lines: string[]) {
   } as unknown as vscode.TextEditor
 }
 
-function pluginResolver(service: DecorationService) {
-  return internals(service).phases[0].resolver
-}
-
-function hoverResolver(service: DecorationService) {
-  return internals(service).phases[1].resolver
-}
-
-function semanticTokenResolver(service: DecorationService) {
-  return internals(service).phases[2].resolver
-}
-
-function stubAllResolvers(service: DecorationService) {
-  for (const { resolver } of internals(service).phases) {
-    vi.spyOn(resolver, 'resolve').mockResolvedValue(undefined)
-  }
-}
-
 function createMockProbe() {
   const probe = new TypeScriptServerProbe()
   vi.spyOn(probe, 'waitForReady').mockResolvedValue(true)
+  vi.spyOn(probe, 'cancel')
+  vi.spyOn(probe, 'dispose')
   return probe
+}
+
+type ResolveMethod = (document: vscode.TextDocument, position: vscode.Position) => Promise<SymbolKind | undefined>
+
+function spyResolve(prototype: { resolve: ResolveMethod }) {
+  return vi.spyOn(prototype as { resolve: ResolveMethod }, 'resolve')
+}
+
+function stubAllResolvers() {
+  spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(undefined)
+  spyResolve(HoverSymbolResolver.prototype).mockResolvedValue(undefined)
+  spyResolve(SemanticTokenSymbolResolver.prototype).mockResolvedValue(undefined)
 }
 
 describe('DecorationService', () => {
@@ -99,12 +92,11 @@ describe('DecorationService', () => {
     vi.mocked(vscode.commands.executeCommand).mockReset()
     vi.mocked(vscode.window.createTextEditorDecorationType).mockClear()
 
-    // Explicitly stub all resolver methods to undefined by default.
-    // Tests that need a specific resolver to return a value will override the relevant spy.
-    stubAllResolvers(service)
+    stubAllResolvers()
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
   })
 
@@ -136,7 +128,7 @@ describe('DecorationService', () => {
         mockParserReturn(service, [
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor(["import { useState } from 'react'"])
         await service.applyImportDecorations(editor)
@@ -149,17 +141,16 @@ describe('DecorationService', () => {
     })
 
     describe('symbol occurrences', () => {
-      it('should find same symbol on multiple lines', async () => {
+      it('should decorate multiple symbols with the same color', async () => {
         mockParserReturn(service, [
           stmt({ localName: 'Foo', source: 'a', startLine: 0, startColumn: 9, endLine: 0, endColumn: 12 }),
-          stmt({ localName: 'Foo', source: 'b', startLine: 1, startColumn: 9, endLine: 1, endColumn: 12 }),
+          stmt({ localName: 'Bar', source: 'b', startLine: 1, startColumn: 9, endLine: 1, endColumn: 12 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Class)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Class)
 
-        const editor = createMockEditor(["import { Foo } from 'a'", "import { Foo } from 'b'"])
+        const editor = createMockEditor(["import { Foo } from 'a'", "import { Bar } from 'b'"])
         await service.applyImportDecorations(editor)
 
-        // Should find Foo on both lines
         const setDecorationsCalls = vi.mocked(editor.setDecorations).mock.calls
         const decorationCall = setDecorationsCalls.find((call) => Array.isArray(call[1]) && call[1].length > 0)
         expect(decorationCall).toBeDefined()
@@ -173,7 +164,7 @@ describe('DecorationService', () => {
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
           stmt({ localName: 'useEffect', source: 'react', startLine: 0, startColumn: 19, endLine: 0, endColumn: 28 }),
         ])
-        const spy = vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        const spy = spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor(["import { useState, useEffect } from 'react'"])
         await service.applyImportDecorations(editor)
@@ -189,7 +180,6 @@ describe('DecorationService', () => {
         const editor = createMockEditor(["import { unknown } from 'mod'"])
         await service.applyImportDecorations(editor)
 
-        // No decoration type should be created for unresolved symbols
         expect(vscode.window.createTextEditorDecorationType).not.toHaveBeenCalled()
       })
 
@@ -210,7 +200,7 @@ describe('DecorationService', () => {
 
         let concurrent = 0
         let maxConcurrent = 0
-        vi.spyOn(pluginResolver(service), 'resolve').mockImplementation(async () => {
+        spyResolve(PluginSymbolResolver.prototype).mockImplementation(async () => {
           concurrent++
           maxConcurrent = Math.max(maxConcurrent, concurrent)
           await new Promise((r) => setTimeout(r, 10))
@@ -229,12 +219,11 @@ describe('DecorationService', () => {
         mockParserReturn(service, [
           stmt({ localName: 'failing', startLine: 0, startColumn: 9, endLine: 0, endColumn: 16 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockRejectedValue(new Error('resolution failed'))
+        spyResolve(PluginSymbolResolver.prototype).mockRejectedValue(new Error('resolution failed'))
 
         const editor = createMockEditor(["import { failing } from 'mod'"])
         await service.applyImportDecorations(editor)
 
-        // Should not throw, and should not apply any decoration
         expect(vscode.window.createTextEditorDecorationType).not.toHaveBeenCalled()
       })
 
@@ -242,13 +231,12 @@ describe('DecorationService', () => {
         mockParserReturn(service, [
           stmt({ localName: 'mySymbol', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
-        vi.spyOn(hoverResolver(service), 'resolve').mockResolvedValue(SymbolKind.Class)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
+        spyResolve(HoverSymbolResolver.prototype).mockResolvedValue(SymbolKind.Class)
 
         const editor = createMockEditor(["import { mySymbol } from 'mod'"])
         await service.applyImportDecorations(editor)
 
-        // Plugin (Phase 1) result should be preserved, not overwritten by Hover (Phase 2)
         expect(vscode.window.createTextEditorDecorationType).toHaveBeenCalledWith({
           color: TEST_COLORS[SymbolKind.Function],
         })
@@ -259,17 +247,15 @@ describe('DecorationService', () => {
           stmt({ localName: 'resolved', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
           stmt({ localName: 'unresolved', startLine: 0, startColumn: 19, endLine: 0, endColumn: 29 }),
         ])
-        vi.spyOn(hoverResolver(service), 'resolve').mockImplementation(async (_doc, pos) => {
+        spyResolve(HoverSymbolResolver.prototype).mockImplementation(async (_doc, pos) => {
           return pos.character === 9 ? SymbolKind.Function : undefined
         })
-        vi.spyOn(semanticTokenResolver(service), 'resolve').mockResolvedValue(SymbolKind.Variable)
+        spyResolve(SemanticTokenSymbolResolver.prototype).mockResolvedValue(SymbolKind.Variable)
 
         const editor = createMockEditor(["import { resolved, unresolved } from 'mod'"])
         await service.applyImportDecorations(editor)
 
-        const semanticSpy = vi.mocked(semanticTokenResolver(service).resolve)
-        // SemanticToken should only be called for 'unresolved' (hover returned undefined)
-        expect(semanticSpy).toHaveBeenCalledTimes(1)
+        expect(SemanticTokenSymbolResolver.prototype.resolve).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -278,7 +264,7 @@ describe('DecorationService', () => {
         mockParserReturn(service, [
           stmt({ localName: 'myFn', startLine: 0, startColumn: 9, endLine: 0, endColumn: 13 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor(["import { myFn } from 'mod'"])
         await service.applyImportDecorations(editor)
@@ -293,7 +279,7 @@ describe('DecorationService', () => {
           stmt({ localName: 'ClassA', startLine: 0, startColumn: 9, endLine: 0, endColumn: 15 }),
           stmt({ localName: 'ClassB', startLine: 0, startColumn: 17, endLine: 0, endColumn: 23 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Class)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Class)
 
         const editor = createMockEditor(["import { ClassA, ClassB } from 'mod'"])
         await service.applyImportDecorations(editor)
@@ -308,15 +294,13 @@ describe('DecorationService', () => {
           stmt({ localName: 'myFn', startLine: 0, startColumn: 9, endLine: 0, endColumn: 13 }),
           stmt({ localName: 'MyClass', startLine: 0, startColumn: 15, endLine: 0, endColumn: 22 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockImplementation(async (_doc, pos) => {
-          // myFn at char 9, MyClass at char 15
+        spyResolve(PluginSymbolResolver.prototype).mockImplementation(async (_doc, pos) => {
           return pos.character < 14 ? SymbolKind.Function : SymbolKind.Class
         })
 
         const editor = createMockEditor(["import { myFn, MyClass } from 'mod'"])
         await service.applyImportDecorations(editor)
 
-        // Two different decoration types should be created (Function color + Class color)
         expect(vscode.window.createTextEditorDecorationType).toHaveBeenCalledWith({
           color: TEST_COLORS[SymbolKind.Function],
         })
@@ -328,20 +312,18 @@ describe('DecorationService', () => {
       it('should skip symbols whose kind has no color in the map', async () => {
         const partialColors: SymbolColorMap = { [SymbolKind.Function]: '#DCDCAA' }
         service = new DecorationService(partialColors, mockProbe)
-        stubAllResolvers(service)
 
         mockParserReturn(service, [
           stmt({ localName: 'myFn', startLine: 0, startColumn: 9, endLine: 0, endColumn: 13 }),
           stmt({ localName: 'MyClass', startLine: 0, startColumn: 15, endLine: 0, endColumn: 22 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockImplementation(async (_doc, pos) => {
+        spyResolve(PluginSymbolResolver.prototype).mockImplementation(async (_doc, pos) => {
           return pos.character < 14 ? SymbolKind.Function : SymbolKind.Class
         })
 
         const editor = createMockEditor(["import { myFn, MyClass } from 'mod'"])
         await service.applyImportDecorations(editor)
 
-        // Only Function color should be created (Class has no color in partialColors)
         expect(vscode.window.createTextEditorDecorationType).toHaveBeenCalledTimes(1)
         expect(vscode.window.createTextEditorDecorationType).toHaveBeenCalledWith({
           color: '#DCDCAA',
@@ -350,12 +332,11 @@ describe('DecorationService', () => {
 
       it('should not apply any decorations when colors map is empty', async () => {
         service = new DecorationService({}, mockProbe)
-        stubAllResolvers(service)
 
         mockParserReturn(service, [
           stmt({ localName: 'myFn', startLine: 0, startColumn: 9, endLine: 0, endColumn: 13 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor(["import { myFn } from 'mod'"])
         await service.applyImportDecorations(editor)
@@ -369,7 +350,7 @@ describe('DecorationService', () => {
         mockParserReturn(service, [
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor(["import { useState } from 'react'"])
         await service.applyImportDecorations(editor)
@@ -391,7 +372,7 @@ describe('DecorationService', () => {
         mockParserReturn(service, [
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
         ])
-        const spy = vi.spyOn(pluginResolver(service), 'resolve')
+        const spy = spyResolve(PluginSymbolResolver.prototype)
 
         const editor = createMockEditor([importLine])
         await service.applyImportDecorations(editor)
@@ -410,7 +391,7 @@ describe('DecorationService', () => {
         mockParserReturn(service, [
           stmt({ localName: 'useEffect', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 18 }),
         ])
-        const spy = vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        const spy = spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor(["import { useEffect } from 'react'"])
         await service.applyImportDecorations(editor)
@@ -431,7 +412,7 @@ describe('DecorationService', () => {
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
           stmt({ localName: 'useEffect', source: 'react', startLine: 0, startColumn: 19, endLine: 0, endColumn: 28 }),
         ])
-        const spy = vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        const spy = spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor([importText])
         await service.applyImportDecorations(editor)
@@ -453,12 +434,10 @@ describe('DecorationService', () => {
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
           stmt({ localName: 'useEffect', source: 'react', startLine: 0, startColumn: 19, endLine: 0, endColumn: 28 }),
         ])
-        // All resolvers fail for useEffect (return undefined by default from stubAllResolvers)
 
         const editor = createMockEditor([importText])
         await service.applyImportDecorations(editor)
 
-        // Cached useState should still be decorated despite useEffect failing
         const calls = vi.mocked(editor.setDecorations).mock.calls
         const decoratedCall = calls.find((call) => Array.isArray(call[1]) && call[1].length > 0)
         expect(decoratedCall).toBeDefined()
@@ -478,7 +457,7 @@ describe('DecorationService', () => {
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
           stmt({ localName: 'useEffect', source: 'react', startLine: 0, startColumn: 19, endLine: 0, endColumn: 28 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor([importText])
         await service.applyImportDecorations(editor)
@@ -489,127 +468,21 @@ describe('DecorationService', () => {
       })
     })
 
-    describe('tsserver loading retry', () => {
-      it('should schedule a retry when hover resolver throws TsServerLoadingError', async () => {
-        mockParserReturn(service, [
-          stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
-        ])
-        vi.spyOn(hoverResolver(service), 'resolve').mockRejectedValue(new TsServerLoadingError())
-
-        const editor = createMockEditor(["import { useState } from 'react'"])
-        await service.applyImportDecorations(editor)
-
-        expect(internals(service).retryTimeouts.has(editor.document.uri.toString())).toBe(true)
-      })
-
-      it('should not schedule retry when max retries exceeded', async () => {
-        mockParserReturn(service, [
-          stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
-        ])
-        vi.spyOn(hoverResolver(service), 'resolve').mockRejectedValue(new TsServerLoadingError())
-
-        const editor = createMockEditor(["import { useState } from 'react'"])
-        await service.applyImportDecorations(editor, 5)
-
-        expect(internals(service).retryTimeouts.has(editor.document.uri.toString())).toBe(false)
-      })
-
-      it('should cancel pending retry when new decoration is requested', async () => {
-        mockParserReturn(service, [
-          stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
-        ])
-        vi.spyOn(hoverResolver(service), 'resolve').mockRejectedValue(new TsServerLoadingError())
-
-        const editor = createMockEditor(["import { useState } from 'react'"])
-        await service.applyImportDecorations(editor)
-
-        const firstTimeout = internals(service).retryTimeouts.get(editor.document.uri.toString())
-        expect(firstTimeout).toBeDefined()
-
-        // Trigger new decoration request — should cancel the pending retry
-        await service.applyImportDecorations(editor)
-
-        const secondTimeout = internals(service).retryTimeouts.get(editor.document.uri.toString())
-        expect(secondTimeout).not.toBe(firstTimeout)
-      })
-
-      it('should execute retry after timeout fires', async () => {
-        mockParserReturn(service, [
-          stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
-        ])
-        const resolveSpy = vi
-          .spyOn(hoverResolver(service), 'resolve')
-          .mockRejectedValueOnce(new TsServerLoadingError())
-          .mockResolvedValueOnce(SymbolKind.Function)
-
-        const editor = createMockEditor(["import { useState } from 'react'"])
-        await service.applyImportDecorations(editor)
-
-        // Fast-forward timer to trigger the retry
-        await vi.advanceTimersByTimeAsync(500)
-
-        // Resolver should have been called twice (initial + retry)
-        expect(resolveSpy).toHaveBeenCalledTimes(2)
-      })
-
-      it('should not schedule retry for non-TsServerLoadingError when some symbols resolve', async () => {
-        mockParserReturn(service, [
-          stmt({ localName: 'useState', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
-          stmt({ localName: 'broken', startLine: 0, startColumn: 19, endLine: 0, endColumn: 25 }),
-        ])
-        vi.spyOn(hoverResolver(service), 'resolve').mockImplementation(async (_doc, pos) => {
-          if (pos.character === 9) {
-            return SymbolKind.Function
-          }
-          throw new Error('other error')
-        })
-
-        const editor = createMockEditor(["import { useState, broken } from 'react'"])
-        await service.applyImportDecorations(editor)
-
-        expect(internals(service).retryTimeouts.has(editor.document.uri.toString())).toBe(false)
-      })
-
-      it('should still apply partial decorations when some symbols resolve and others are loading', async () => {
-        mockParserReturn(service, [
-          stmt({ localName: 'useState', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
-          stmt({ localName: 'MyClass', startLine: 0, startColumn: 19, endLine: 0, endColumn: 26 }),
-        ])
-        vi.spyOn(hoverResolver(service), 'resolve').mockImplementation(async (_doc, pos) => {
-          if (pos.character === 9) {
-            return SymbolKind.Function
-          }
-          throw new TsServerLoadingError()
-        })
-
-        const editor = createMockEditor(["import { useState, MyClass } from 'mod'"])
-        await service.applyImportDecorations(editor)
-
-        // Partial decoration should be applied for useState
-        const calls = vi.mocked(editor.setDecorations).mock.calls
-        const decoratedCall = calls.find((call) => Array.isArray(call[1]) && call[1].length > 0)
-        expect(decoratedCall).toBeDefined()
-
-        // Retry should be scheduled for MyClass
-        expect(internals(service).retryTimeouts.has(editor.document.uri.toString())).toBe(true)
-      })
-    })
-
     describe('tsserver probe', () => {
       it('should call probe.waitForReady before resolver pipeline when symbols need resolving', async () => {
         mockParserReturn(service, [
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor(["import { useState } from 'react'"])
         await service.applyImportDecorations(editor)
 
         expect(mockProbe.waitForReady).toHaveBeenCalledOnce()
         expect(mockProbe.waitForReady).toHaveBeenCalledWith(
+          editor.document.uri.toString(),
           editor.document,
           expect.objectContaining({ line: 0, character: 9 }),
-          expect.any(AbortSignal),
         )
       })
 
@@ -632,125 +505,38 @@ describe('DecorationService', () => {
         expect(mockProbe.waitForReady).not.toHaveBeenCalled()
       })
 
-      it('should abort previous probe when new decoration request arrives', async () => {
-        vi.mocked(mockProbe.waitForReady)
-          .mockImplementationOnce(
-            (_doc, _pos, signal) =>
-              new Promise<boolean>((resolve) => {
-                signal.addEventListener('abort', () => resolve(false), { once: true })
-              }),
-          )
-          .mockResolvedValueOnce(true)
-
+      it('should cancel previous probe when new decoration request arrives', async () => {
         mockParserReturn(service, [
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
         ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor(["import { useState } from 'react'"])
 
-        // First call starts probe (blocks on promise)
-        const firstPromise = service.applyImportDecorations(editor)
-        await vi.advanceTimersByTimeAsync(0)
+        await service.applyImportDecorations(editor)
+        await service.applyImportDecorations(editor)
 
-        // Second call should abort the first probe
-        const secondPromise = service.applyImportDecorations(editor)
-        await vi.advanceTimersByTimeAsync(0)
-
-        await Promise.all([firstPromise, secondPromise])
-
-        // First probe should have been aborted, second should proceed
-        expect(mockProbe.waitForReady).toHaveBeenCalledTimes(2)
+        expect(mockProbe.cancel).toHaveBeenCalledWith(editor.document.uri.toString())
       })
 
-      it('should return early when probe is cancelled (signal aborted)', async () => {
-        vi.mocked(mockProbe.waitForReady).mockImplementation(async (_doc, _pos, signal) => {
-          // Simulate abort during wait
-          return !signal.aborted
-        })
+      it('should return early when probe returns false (cancelled)', async () => {
+        vi.mocked(mockProbe.waitForReady).mockResolvedValue(false)
 
         mockParserReturn(service, [
           stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
         ])
-        const spy = vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
+        const spy = spyResolve(PluginSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
 
         const editor = createMockEditor(["import { useState } from 'react'"])
+        await service.applyImportDecorations(editor)
 
-        // Manually abort before probe completes
-        const firstPromise = service.applyImportDecorations(editor)
-        internals(service).probeControllers.get(editor.document.uri.toString())?.abort()
-        await firstPromise
-
-        // Resolver should not have been called since probe was aborted
         expect(spy).not.toHaveBeenCalled()
       })
 
-      it('should proceed with resolvers even when probe times out', async () => {
-        vi.mocked(mockProbe.waitForReady).mockResolvedValue(false)
-        mockParserReturn(service, [
-          stmt({ localName: 'useState', source: 'react', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
-        ])
-        const spy = vi.spyOn(pluginResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
-
-        const editor = createMockEditor(["import { useState } from 'react'"])
-        await service.applyImportDecorations(editor)
-
-        expect(spy).toHaveBeenCalled()
-      })
-
-      it('should clean up probe controllers on dispose', () => {
-        const controller = new AbortController()
-        const abortSpy = vi.spyOn(controller, 'abort')
-        internals(service).probeControllers.set('file:///a.ts', controller)
-
+      it('should call probe.dispose on service dispose', () => {
         service.dispose()
 
-        expect(abortSpy).toHaveBeenCalledOnce()
-        expect(internals(service).probeControllers.size).toBe(0)
-      })
-    })
-
-    describe('post-resolve fallback', () => {
-      it('should schedule retry when all symbols remain unresolved', async () => {
-        mockParserReturn(service, [
-          stmt({ localName: 'unknown', startLine: 0, startColumn: 9, endLine: 0, endColumn: 16 }),
-        ])
-        // All resolvers return undefined (from stubAllResolvers)
-
-        const editor = createMockEditor(["import { unknown } from 'mod'"])
-        await service.applyImportDecorations(editor)
-
-        // Should schedule retry because all symbols are unresolved
-        expect(internals(service).retryTimeouts.has(editor.document.uri.toString())).toBe(true)
-      })
-
-      it('should not schedule fallback retry when at least one symbol was resolved', async () => {
-        mockParserReturn(service, [
-          stmt({ localName: 'resolved', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
-          stmt({ localName: 'unresolved', startLine: 0, startColumn: 19, endLine: 0, endColumn: 29 }),
-        ])
-        vi.spyOn(pluginResolver(service), 'resolve').mockImplementation(async (_doc, pos) => {
-          return pos.character === 9 ? SymbolKind.Function : undefined
-        })
-
-        const editor = createMockEditor(["import { resolved, unresolved } from 'mod'"])
-        await service.applyImportDecorations(editor)
-
-        // Should NOT schedule retry because 'resolved' was resolved
-        expect(internals(service).retryTimeouts.has(editor.document.uri.toString())).toBe(false)
-      })
-
-      it('should not double-schedule retry when TsServerLoadingError already triggered retry', async () => {
-        mockParserReturn(service, [
-          stmt({ localName: 'loading', startLine: 0, startColumn: 9, endLine: 0, endColumn: 16 }),
-        ])
-        vi.spyOn(hoverResolver(service), 'resolve').mockRejectedValue(new TsServerLoadingError())
-
-        const editor = createMockEditor(["import { loading } from 'mod'"])
-        await service.applyImportDecorations(editor)
-
-        // tsServerLoading is already true from TsServerLoadingError, fallback should not override
-        expect(internals(service).retryTimeouts.has(editor.document.uri.toString())).toBe(true)
+        expect(mockProbe.dispose).toHaveBeenCalledOnce()
       })
     })
 
@@ -761,34 +547,28 @@ describe('DecorationService', () => {
           stmt({ localName: 'MyClass', startLine: 0, startColumn: 15, endLine: 0, endColumn: 22 }),
         ])
 
-        // Plugin resolves myFn immediately, leaves MyClass unresolved
-        vi.spyOn(pluginResolver(service), 'resolve').mockImplementation(async (_doc, pos) => {
+        spyResolve(PluginSymbolResolver.prototype).mockImplementation(async (_doc, pos) => {
           return pos.character === 9 ? SymbolKind.Function : undefined
         })
 
-        // Block Hover with a deferred promise
         let resolveHover!: (value: SymbolKind | undefined) => void
         const hoverPromise = new Promise<SymbolKind | undefined>((resolve) => {
           resolveHover = resolve
         })
-        vi.spyOn(hoverResolver(service), 'resolve').mockImplementation(async () => hoverPromise)
+        spyResolve(HoverSymbolResolver.prototype).mockImplementation(async () => hoverPromise)
 
         const editor = createMockEditor(["import { myFn, MyClass } from 'mod'"])
         const applyPromise = service.applyImportDecorations(editor)
 
-        // Flush microtasks to let Plugin phase complete and decorations to be applied
         await vi.advanceTimersByTimeAsync(0)
 
-        // Plugin resolved myFn, decorations should already be applied before Hover completes
         const callsBefore = vi.mocked(editor.setDecorations).mock.calls
         const decoratedBefore = callsBefore.filter((call) => Array.isArray(call[1]) && call[1].length > 0)
         expect(decoratedBefore.length).toBeGreaterThanOrEqual(1)
 
-        // Resolve Hover for MyClass and wait for all phases to complete
         resolveHover(SymbolKind.Class)
         await applyPromise
 
-        // After all phases, additional decoration updates should have been made
         const callsAfter = vi.mocked(editor.setDecorations).mock.calls
         const decoratedAfter = callsAfter.filter((call) => Array.isArray(call[1]) && call[1].length > 0)
         expect(decoratedAfter.length).toBeGreaterThan(decoratedBefore.length)
@@ -798,8 +578,8 @@ describe('DecorationService', () => {
         mockParserReturn(service, [
           stmt({ localName: 'myFn', startLine: 0, startColumn: 9, endLine: 0, endColumn: 13 }),
         ])
-        vi.spyOn(hoverResolver(service), 'resolve').mockResolvedValue(SymbolKind.Function)
-        const semanticSpy = vi.spyOn(semanticTokenResolver(service), 'resolve')
+        spyResolve(HoverSymbolResolver.prototype).mockResolvedValue(SymbolKind.Function)
+        const semanticSpy = spyResolve(SemanticTokenSymbolResolver.prototype)
 
         const editor = createMockEditor(["import { myFn } from 'mod'"])
         await service.applyImportDecorations(editor)
@@ -812,10 +592,12 @@ describe('DecorationService', () => {
           stmt({ localName: 'resolved', startLine: 0, startColumn: 9, endLine: 0, endColumn: 17 }),
           stmt({ localName: 'unresolved', startLine: 0, startColumn: 19, endLine: 0, endColumn: 29 }),
         ])
-        vi.spyOn(hoverResolver(service), 'resolve').mockImplementation(async (_doc, pos) => {
+        spyResolve(HoverSymbolResolver.prototype).mockImplementation(async (_doc, pos) => {
           return pos.character === 9 ? SymbolKind.Function : undefined
         })
-        const semanticSpy = vi.spyOn(semanticTokenResolver(service), 'resolve').mockResolvedValue(SymbolKind.Variable)
+        const semanticSpy = vi
+          .spyOn(SemanticTokenSymbolResolver.prototype, 'resolve')
+          .mockResolvedValue(SymbolKind.Variable)
 
         const editor = createMockEditor(["import { resolved, unresolved } from 'mod'"])
         await service.applyImportDecorations(editor)
@@ -923,17 +705,6 @@ describe('DecorationService', () => {
       expect(() => service.dispose()).not.toThrow()
       expect(internals(service).decorationTypes.size).toBe(0)
       expect(internals(service).documentCaches.size).toBe(0)
-    })
-
-    it('should clear all pending retry timeouts', () => {
-      const timeout1 = setTimeout(() => {}, 1000)
-      const timeout2 = setTimeout(() => {}, 2000)
-      internals(service).retryTimeouts.set('file:///a.ts', timeout1)
-      internals(service).retryTimeouts.set('file:///b.ts', timeout2)
-
-      service.dispose()
-
-      expect(internals(service).retryTimeouts.size).toBe(0)
     })
   })
 

--- a/src/decoration/service.ts
+++ b/src/decoration/service.ts
@@ -1,40 +1,28 @@
-import PQueue from 'p-queue'
 import * as vscode from 'vscode'
 import { TypeScriptParser } from '../parser'
-import type { BaseSymbolResolver, SymbolKind } from '../symbol'
-import { HoverSymbolResolver, PluginSymbolResolver, SemanticTokenSymbolResolver, TsServerLoadingError } from '../symbol'
+import type { SymbolKind } from '../symbol'
 import { Logger } from '../logger'
 import type { SymbolColorMap } from '../theme'
 import { TypeScriptServerProbe } from '../tsServer'
+import { SymbolResolver } from './resolver'
 import type { DocumentCache, SymbolOccurrence } from './types'
 
-const MAX_RETRIES = 5
-const RETRY_DELAY_MS = 500
-const CONCURRENCY_LIMIT = 5
-
-interface ResolverPhase {
-  resolver: BaseSymbolResolver
+interface DecorationContext {
+  occurrences: Map<string, SymbolOccurrence>
+  importSectionText: string
 }
 
 export class DecorationService implements vscode.Disposable {
   private readonly logger = Logger.create(DecorationService)
-  private readonly phases: ResolverPhase[]
   private readonly probe: TypeScriptServerProbe
   private readonly decorationTypes = new Map<string, vscode.TextEditorDecorationType>()
   private readonly documentCaches = new Map<string, DocumentCache>()
-  private readonly retryTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
-  private readonly probeControllers = new Map<string, AbortController>()
   private readonly parser = new TypeScriptParser()
   private colors: SymbolColorMap
 
   constructor(colors: SymbolColorMap = {}, probe?: TypeScriptServerProbe) {
     this.colors = colors
     this.probe = probe ?? new TypeScriptServerProbe()
-    this.phases = [
-      { resolver: new PluginSymbolResolver() },
-      { resolver: new HoverSymbolResolver() },
-      { resolver: new SemanticTokenSymbolResolver() },
-    ]
   }
 
   setColors(colors: SymbolColorMap) {
@@ -45,159 +33,64 @@ export class DecorationService implements vscode.Disposable {
     this.decorationTypes.clear()
   }
 
-  async applyImportDecorations(editor: vscode.TextEditor, retryCount = 0) {
+  async applyImportDecorations(editor: vscode.TextEditor) {
     const document = editor.document
     const docUri = document.uri.toString()
 
-    // Cancel any pending retry and probe for this document
-    this.cancelRetry(docUri)
-    this.cancelProbe(docUri)
+    this.probe.cancel(docUri)
+    this.clearDecorations(editor)
 
-    const text = document.getText()
-    const statements = this.parser.parseImports(text)
-
-    // Clear all existing decorations
-    for (const type of this.decorationTypes.values()) {
-      editor.setDecorations(type, [])
-    }
-
-    if (statements.length === 0) {
+    const context = this.buildContext(document)
+    if (!context) {
       return
     }
 
-    // Build occurrences and source map from parsed statements
-    const occurrences = statements.map(
-      (s): SymbolOccurrence => ({
-        symbol: s.localName,
-        range: new vscode.Range(s.startLine, s.startColumn, s.endLine, s.endColumn),
-      }),
-    )
-    const symbolSources: Record<string, string> = {}
-    for (const { localName, source } of statements) {
-      symbolSources[localName] ??= source
+    const { symbolKinds, targetsToResolve } = this.loadCachedKinds(docUri, context)
+
+    if (targetsToResolve.size === 0) {
+      this.logger.debug(`all ${symbolKinds.size} symbols resolved from cache`)
+      this.applyDecorationsToEditor(editor, context.occurrences, symbolKinds)
+      return
     }
 
-    // Precompute first occurrence of each symbol for O(1) lookup
-    const occurrenceBySymbol = new Map<string, SymbolOccurrence>()
-    for (const occurrence of occurrences) {
-      if (!occurrenceBySymbol.has(occurrence.symbol)) {
-        occurrenceBySymbol.set(occurrence.symbol, occurrence)
-      }
+    this.logger.info(`resolving ${targetsToResolve.size} symbols, ${symbolKinds.size} from cache`)
+
+    const [, firstTarget] = targetsToResolve.entries().next().value!
+    const proceed = await this.probe.waitForReady(docUri, document, firstTarget.range.start)
+    if (!proceed) {
+      return
     }
 
-    // Resolve kind for each unique symbol, using cache when possible
-    const importEndLine = Math.max(...statements.map((s) => s.endLine)) + 1
-    const importSectionText = text.split('\n').slice(0, importEndLine).join('\n')
-    const cached = this.documentCaches.get(docUri)
-    const symbolKinds = new Map<string, SymbolKind>()
-    const uniqueSymbols = [...occurrenceBySymbol.keys()]
-
-    // Reuse cached kinds only if import section is unchanged
-    const reusableCache = cached && cached.importSectionText === importSectionText ? cached.symbolKinds : null
-    const symbolsToResolve: string[] = []
-
-    for (const symbol of uniqueSymbols) {
-      const kind = reusableCache?.get(symbol)
-      if (kind) {
+    const resolver = new SymbolResolver(document, targetsToResolve)
+    resolver.onPhase((phaseKinds) => {
+      for (const [symbol, kind] of phaseKinds) {
         symbolKinds.set(symbol, kind)
-      } else {
-        symbolsToResolve.push(symbol)
       }
+      this.applyDecorationsToEditor(editor, context.occurrences, symbolKinds)
+    })
+
+    const resolved = await resolver.resolve()
+
+    for (const [symbol, kind] of resolved) {
+      symbolKinds.set(symbol, kind)
     }
 
-    let tsServerLoading = false
-
-    if (symbolsToResolve.length > 0) {
-      this.logger.info(`resolving ${symbolsToResolve.length} symbols, ${symbolKinds.size} from cache`)
-
-      // Probe tsserver readiness before entering resolve pipeline
-      const probeTarget = occurrenceBySymbol.get(symbolsToResolve[0])
-      if (probeTarget) {
-        const controller = new AbortController()
-        this.probeControllers.set(docUri, controller)
-
-        const ready = await this.probe.waitForReady(document, probeTarget.range.start, controller.signal)
-        if (this.probeControllers.get(docUri) === controller) {
-          this.probeControllers.delete(docUri)
-        }
-
-        if (controller.signal.aborted) {
-          return
-        }
-        if (!ready) {
-          this.logger.warn('tsserver probe not ready, proceeding with resolve pipeline')
-        }
-      }
-
-      for (const { resolver } of this.phases) {
-        const targets = symbolsToResolve.filter((s) => !symbolKinds.has(s))
-        if (targets.length === 0) {
-          continue
-        }
-
-        const previousSize = symbolKinds.size
-        const loading = await this.resolveSymbols(
-          resolver,
-          targets,
-          occurrenceBySymbol,
-          document,
-          symbolKinds,
-          symbolSources,
-        )
-        if (loading) {
-          tsServerLoading = true
-        }
-        if (symbolKinds.size !== previousSize) {
-          this.applyDecorationsToEditor(editor, occurrences, symbolKinds)
-        }
-      }
-
-      const unresolved = symbolsToResolve.filter((s) => !symbolKinds.has(s))
-      if (unresolved.length > 0) {
-        this.logger.info(`could not resolve: ${unresolved.map((s) => `'${s}'`).join(', ')}`)
-      }
-
-      // Post-resolve fallback: if ALL symbols to resolve failed, treat as tsserver not ready
-      if (unresolved.length === symbolsToResolve.length && !tsServerLoading) {
-        this.logger.info('all symbols unresolved, treating as tsserver not ready')
-        tsServerLoading = true
-      }
-
-      this.applyDecorationsToEditor(editor, occurrences, symbolKinds)
-      this.documentCaches.set(docUri, { importSectionText, symbolKinds: new Map(symbolKinds) })
-    } else {
-      this.logger.debug(`all ${uniqueSymbols.length} symbols resolved from cache`)
-      this.applyDecorationsToEditor(editor, occurrences, symbolKinds)
+    const unresolved = [...targetsToResolve.keys()].filter((s) => !symbolKinds.has(s))
+    if (unresolved.length > 0) {
+      this.logger.info(`could not resolve: ${unresolved.map((s) => `'${s}'`).join(', ')}`)
     }
 
-    if (tsServerLoading && retryCount < MAX_RETRIES) {
-      const delay = RETRY_DELAY_MS * (retryCount + 1)
-      this.logger.warn(`waiting for tsserver, retrying in ${delay}ms (attempt ${retryCount + 1}/${MAX_RETRIES})`)
-      const timeout = setTimeout(() => {
-        this.retryTimeouts.delete(docUri)
-        this.applyImportDecorations(editor, retryCount + 1).catch(() => {
-          // Retry may fail; silently ignore
-        })
-      }, delay)
-      this.retryTimeouts.set(docUri, timeout)
-    }
+    this.applyDecorationsToEditor(editor, context.occurrences, symbolKinds)
+    this.documentCaches.set(docUri, { importSectionText: context.importSectionText, symbolKinds: new Map(symbolKinds) })
   }
 
   clearDocumentCache(uri: string) {
-    this.cancelRetry(uri)
-    this.cancelProbe(uri)
+    this.probe.cancel(uri)
     this.documentCaches.delete(uri)
   }
 
   dispose() {
-    for (const timeout of this.retryTimeouts.values()) {
-      clearTimeout(timeout)
-    }
-    this.retryTimeouts.clear()
-    for (const controller of this.probeControllers.values()) {
-      controller.abort()
-    }
-    this.probeControllers.clear()
+    this.probe.dispose()
     for (const type of this.decorationTypes.values()) {
       type.dispose()
     }
@@ -205,63 +98,69 @@ export class DecorationService implements vscode.Disposable {
     this.documentCaches.clear()
   }
 
-  private async resolveSymbols(
-    resolver: BaseSymbolResolver,
-    symbols: string[],
-    occurrenceBySymbol: Map<string, SymbolOccurrence>,
-    document: vscode.TextDocument,
-    symbolKinds: Map<string, SymbolKind>,
-    symbolSources: Record<string, string>,
-  ) {
-    let tsServerLoading = false
+  private buildContext(document: vscode.TextDocument): DecorationContext | null {
+    const text = document.getText()
+    const statements = this.parser.parseImports(text)
 
-    const queue = new PQueue({ concurrency: CONCURRENCY_LIMIT })
-    await queue.addAll(
-      symbols.map((symbol) => async () => {
-        const label = symbolSources[symbol] ? `'${symbol}' from '${symbolSources[symbol]}'` : `'${symbol}'`
-        try {
-          const occurrence = occurrenceBySymbol.get(symbol)
-          if (!occurrence) {
-            return
-          }
-          this.logger.debug(`resolving ${label} via '${resolver.name}' resolver`)
-          const start = performance.now()
-          const kind = await resolver.resolve(document, occurrence.range.start)
-          if (kind && !symbolKinds.has(symbol)) {
-            symbolKinds.set(symbol, kind)
-            const elapsed = Math.round(performance.now() - start)
-            this.logger.info(`resolved ${label} → '${kind}' via '${resolver.name}' resolver (in ${elapsed}ms)`)
-          }
-        } catch (error) {
-          if (error instanceof TsServerLoadingError) {
-            this.logger.warn(`tsserver is still loading, skipping ${label}`)
-            tsServerLoading = true
-          } else {
-            this.logger.warn(
-              `failed to resolve ${label} via '${resolver.name}' resolver:`,
-              error instanceof Error ? error.message : String(error),
-            )
-          }
-        }
-      }),
-    )
+    if (statements.length === 0) {
+      return null
+    }
 
-    return tsServerLoading
+    const occurrences = new Map<string, SymbolOccurrence>()
+    for (const s of statements) {
+      if (!occurrences.has(s.localName)) {
+        occurrences.set(s.localName, {
+          source: s.source,
+          range: new vscode.Range(s.startLine, s.startColumn, s.endLine, s.endColumn),
+        })
+      }
+    }
+
+    const importEndLine = Math.max(...statements.map((s) => s.endLine)) + 1
+    const importSectionText = text.split('\n').slice(0, importEndLine).join('\n')
+
+    return { occurrences, importSectionText }
+  }
+
+  private loadCachedKinds(docUri: string, context: DecorationContext) {
+    const cached = this.documentCaches.get(docUri)
+    const reusableCache = cached && cached.importSectionText === context.importSectionText ? cached.symbolKinds : null
+
+    const symbolKinds = new Map<string, SymbolKind>()
+    const targetsToResolve = new Map<string, SymbolOccurrence>()
+
+    for (const [symbol, occurrence] of context.occurrences) {
+      const kind = reusableCache?.get(symbol)
+      if (kind) {
+        symbolKinds.set(symbol, kind)
+      } else {
+        targetsToResolve.set(symbol, occurrence)
+      }
+    }
+
+    return { symbolKinds, targetsToResolve }
+  }
+
+  private clearDecorations(editor: vscode.TextEditor) {
+    for (const type of this.decorationTypes.values()) {
+      editor.setDecorations(type, [])
+    }
   }
 
   private applyDecorationsToEditor(
     editor: vscode.TextEditor,
-    occurrences: SymbolOccurrence[],
+    occurrences: Map<string, SymbolOccurrence>,
     symbolKinds: Map<string, SymbolKind>,
   ) {
     const rangesByColor = new Map<string, vscode.Range[]>()
 
-    for (const { symbol, range } of occurrences) {
+    for (const [symbol, { range }] of occurrences) {
       const kind = symbolKinds.get(symbol)
       const color = kind ? this.colors[kind] : undefined
       if (!color) {
         continue
       }
+
       const ranges = rangesByColor.get(color) ?? []
       ranges.push(range)
       rangesByColor.set(color, ranges)
@@ -276,22 +175,6 @@ export class DecorationService implements vscode.Disposable {
 
     for (const [color, ranges] of rangesByColor) {
       editor.setDecorations(this.getDecorationType(color), ranges)
-    }
-  }
-
-  private cancelProbe(docUri: string) {
-    const existing = this.probeControllers.get(docUri)
-    if (existing) {
-      existing.abort()
-      this.probeControllers.delete(docUri)
-    }
-  }
-
-  private cancelRetry(docUri: string) {
-    const existing = this.retryTimeouts.get(docUri)
-    if (existing) {
-      clearTimeout(existing)
-      this.retryTimeouts.delete(docUri)
     }
   }
 

--- a/src/decoration/types.ts
+++ b/src/decoration/types.ts
@@ -7,6 +7,6 @@ export interface DocumentCache {
 }
 
 export interface SymbolOccurrence {
-  symbol: string
+  source: string
   range: vscode.Range
 }

--- a/src/tsServer/probe.ts
+++ b/src/tsServer/probe.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { Logger } from '../logger'
 
-const MAX_PROBE_ATTEMPTS = 20
+const DEFAULT_TIMEOUT_MS = 10_000
 const PROBE_INTERVAL_MS = 500
 
 interface QuickInfoResponse {
@@ -10,10 +10,24 @@ interface QuickInfoResponse {
   }
 }
 
-export class TypeScriptServerProbe {
-  private readonly logger = Logger.create(TypeScriptServerProbe)
+export interface ProbeOptions {
+  timeout?: number
+}
 
-  async waitForReady(document: vscode.TextDocument, position: vscode.Position, signal: AbortSignal) {
+export class TypeScriptServerProbe implements vscode.Disposable {
+  private readonly logger = Logger.create(TypeScriptServerProbe)
+  private readonly controllers = new Map<string, AbortController>()
+
+  async waitForReady(key: string, document: vscode.TextDocument, position: vscode.Position, options?: ProbeOptions) {
+    this.cancel(key)
+
+    const controller = new AbortController()
+    this.controllers.set(key, controller)
+    const signal = controller.signal
+
+    const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS
+    const maxAttempts = Math.max(1, Math.ceil(timeout / PROBE_INTERVAL_MS))
+
     try {
       signal.throwIfAborted()
 
@@ -24,7 +38,7 @@ export class TypeScriptServerProbe {
 
       this.logger.info('tsserver not ready, starting probe polling')
 
-      for (let attempt = 1; attempt < MAX_PROBE_ATTEMPTS; attempt++) {
+      for (let attempt = 1; attempt < maxAttempts; attempt++) {
         await this.delay(PROBE_INTERVAL_MS, signal)
 
         const ready = await this.check(document, position)
@@ -34,20 +48,39 @@ export class TypeScriptServerProbe {
           return true
         }
 
-        this.logger.debug(`probe attempt ${attempt + 1}/${MAX_PROBE_ATTEMPTS}: not ready`)
+        this.logger.debug(`probe attempt ${attempt + 1}/${maxAttempts}: not ready`)
       }
 
-      this.logger.warn(`tsserver not ready after ${MAX_PROBE_ATTEMPTS} attempts`)
-      return false
+      this.logger.warn(`tsserver not ready after ${maxAttempts} attempts, proceeding anyway`)
+      return true
     } catch (error) {
       if (signal.aborted) {
         this.logger.info('probe cancelled')
-      } else {
-        const message = error instanceof Error ? error.message : String(error)
-        this.logger.warn('probe failed:', message)
+        return false
       }
-      return false
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger.warn('probe failed:', message)
+      return true
+    } finally {
+      if (this.controllers.get(key) === controller) {
+        this.controllers.delete(key)
+      }
     }
+  }
+
+  cancel(key: string) {
+    const existing = this.controllers.get(key)
+    if (existing) {
+      existing.abort()
+      this.controllers.delete(key)
+    }
+  }
+
+  dispose() {
+    for (const controller of this.controllers.values()) {
+      controller.abort()
+    }
+    this.controllers.clear()
   }
 
   private async check(document: vscode.TextDocument, position: vscode.Position) {

--- a/src/utils/stopwatch.test.ts
+++ b/src/utils/stopwatch.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { stopwatch } from './stopwatch'
+
+describe('stopwatch', () => {
+  it('should return the callback result and elapsed time', async () => {
+    const [result, elapsed] = await stopwatch(async () => 42)
+
+    expect(result).toBe(42)
+    expect(elapsed).toBeGreaterThanOrEqual(0)
+  })
+
+  it('should measure elapsed time of an async callback', async () => {
+    vi.useFakeTimers()
+
+    const promise = stopwatch(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      return 'done'
+    })
+
+    await vi.advanceTimersByTimeAsync(100)
+    const [result, elapsed] = await promise
+
+    expect(result).toBe('done')
+    expect(elapsed).toBeGreaterThanOrEqual(0)
+
+    vi.useRealTimers()
+  })
+
+  it('should propagate errors from the callback', async () => {
+    await expect(
+      stopwatch(async () => {
+        throw new Error('fail')
+      }),
+    ).rejects.toThrow('fail')
+  })
+})

--- a/src/utils/stopwatch.ts
+++ b/src/utils/stopwatch.ts
@@ -1,0 +1,6 @@
+export async function stopwatch<T>(fn: () => Promise<T>): Promise<[T, number]> {
+  const start = performance.now()
+  const result = await fn()
+  const elapsed = Math.round(performance.now() - start)
+  return [result, elapsed]
+}


### PR DESCRIPTION
## 요약

`DecorationService`가 담당하던 심볼 resolve 파이프라인을 `SymbolResolver` 클래스로 추출하고, 중복 데이터 구조를 통합하여 코드 복잡도를 줄였다.

## 변경 사항

- **`SymbolResolver` 클래스 추출** (`src/decoration/resolver.ts`)
  - 호출마다 새 인스턴스를 생성하여 독립적인 resolve 컨텍스트 보장
  - `vscode.EventEmitter`를 통한 `onPhase` 이벤트로 progressive decoration 지원
  - Plugin → Hover → SemanticToken 다단계 resolve + `PQueue` 동시성 제어

- **중복 데이터 구조 통합**
  - `occurrences[]` + `occurrenceBySymbol Map` → 단일 `Map<string, SymbolOccurrence>`
  - `SymbolOccurrence.symbol` 필드 제거 (Map key가 대체)
  - `symbolsToResolve[]` + `targetBySymbol Map` → 단일 `targets Map` 파라미터

- **`TypeScriptServerProbe` 개선**
  - AbortController를 외부가 아닌 probe 내부에서 관리
  - `cancel(key)`, `dispose()` API 제공

- **기타**
  - retry 로직 전면 제거 (probe가 tsserver readiness 보장)
  - `stopwatch` 유틸리티 추가
  - `applyImportDecorations` 메서드 분해
  - eslint `maximumDefaultProjectFileMatchCount` 20 → 25

Closes #72