### PR TITLE
fix(skill): wait for CI version bump before back-merge in release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -26,11 +26,16 @@ disable-model-invocation: true
 - 확인되면 GitHub MCP 도구(`merge_pull_request`)로 **반드시 `merge` 방식**(Create Merge Commit)으로 머지한다. **squash나 rebase를 절대 사용하지 않는다.**
 
 ## 4. 백머지 (main → dev)
-- `git fetch origin`으로 최신 상태를 가져온다.
-- `git checkout dev && git pull origin dev`로 dev 브랜치를 업데이트한다.
-- `git merge origin/main`으로 main을 dev에 백머지한다.
-- 충돌이 발생하면 사용자에게 알리고 수동 해결을 요청한다.
-- 충돌이 없으면 `git push origin dev`로 푸시한다.
+- 머지 후 CI(semantic-release)가 `main`과 `dev` 브랜치에 version bump 커밋을 푸시할 때까지 기다려야 한다.
+- 머지 커밋 SHA를 기준으로, `main` 브랜치에 그 이후의 새로운 커밋(version bump)이 나타날 때까지 폴링한다:
+  - `git fetch origin` 후 `git log <merge_sha>..origin/main --oneline`으로 새 커밋이 있는지 확인한다.
+  - 새 커밋이 없으면 30초 간격으로 재시도하며, 최대 5분간 대기한다.
+  - 5분 내에 새 커밋이 나타나지 않으면 사용자에게 알리고, 백머지를 수동으로 진행하도록 안내한다.
+- version bump 커밋이 확인되면:
+  - `git checkout dev && git pull origin dev`로 dev 브랜치를 업데이트한다.
+  - `git merge origin/main`으로 main을 dev에 백머지한다.
+  - 충돌이 발생하면 사용자에게 알리고 수동 해결을 요청한다.
+  - 충돌이 없으면 `git push origin dev`로 푸시한다.
 
 ## 5. 완료 보고
 - 릴리즈 PR URL, 머지 결과, 백머지 결과를 요약하여 사용자에게 보고한다.


### PR DESCRIPTION
## Summary
- 릴리즈 스킬의 백머지 단계에서 CI(semantic-release)의 version bump 커밋을 기다리도록 수정
- 머지 커밋 SHA 기준으로 `main`에 새 커밋이 나타날 때까지 30초 간격, 최대 5분 폴링
- 타임아웃 시 사용자에게 수동 백머지 안내

## Test plan
- [ ] 다음 릴리즈 시 백머지가 version bump 커밋 포함 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)