### PR TITLE
fix(probe): remove unnecessary quickinfo check from readiness probe

### DIFF
--- a/src/typescript/language/index.ts
+++ b/src/typescript/language/index.ts
@@ -1,3 +1,3 @@
 export { TypeScriptLanguageService } from './languageService'
-export type { DefinitionResult, CompletionInfoResponse, QuickInfoBody } from './languageService'
+export type { DefinitionResult, CompletionInfoResponse } from './languageService'
 export { TypeScriptServerProbe } from './probe'

--- a/src/typescript/language/probe.ts
+++ b/src/typescript/language/probe.ts
@@ -1,7 +1,6 @@
 import { injectable } from 'inversify'
 import * as vscode from 'vscode'
 import { Logger } from '@/logger'
-import { isJavaScriptFile } from '@/utils/isJavaScriptFile'
 import { TypeScriptLanguageService } from './languageService'
 
 const DEFAULT_TIMEOUT_MS = 10_000
@@ -90,33 +89,7 @@ export class TypeScriptServerProbe implements vscode.Disposable {
       return false
     }
 
-    if (definition.targetUri.scheme !== 'file') {
-      return true
-    }
-
-    if (isJavaScriptFile(definition.targetUri.fsPath)) {
-      this.logger.debug('probe: skipping quickinfo for JS target:', definition.targetUri.fsPath)
-      return true
-    }
-
-    try {
-      const body = await this.languageService.requestQuickInfo(
-        definition.targetUri.fsPath,
-        definition.targetRange.start.line + 1,
-        definition.targetRange.start.character + 1,
-      )
-
-      if (body?.kind) {
-        return true
-      }
-
-      this.logger.debug('probe: quickinfo returned empty body')
-      return false
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      this.logger.debug('probe: quickinfo error:', message)
-      return false
-    }
+    return true
   }
 
   private delay(ms: number, signal: AbortSignal) {


### PR DESCRIPTION
## 요약

probe의 readiness 판정에서 불필요한 `requestQuickInfo()` 호출을 제거하고, `getDefinition()` 성공만으로 tsserver ready를 판정하도록 변경했다.

## 변경 사항

- `TypeScriptServerProbe.check()`에서 quickinfo 호출 및 JS 파일 분기 로직 제거
- `getDefinition()`이 유효한 결과를 반환하면 즉시 ready 판정
- quickinfo 관련 테스트 케이스 제거 및 정리
- `QuickInfoBody` re-export 제거 (외부 사용처 없음)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)