### PR TITLE
Release: dev → main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-semantic-imports",
   "displayName": "Semantic Imports",
   "description": "Accurate syntax highlighting for imported symbols in TypeScript",
-  "version": "1.1.2",
+  "version": "1.1.3-dev.1",
   "publisher": "async3619",
   "license": "MIT",
   "icon": "assets/icon.png",

--- a/src/typescript/language/index.ts
+++ b/src/typescript/language/index.ts
@@ -1,3 +1,3 @@
 export { TypeScriptLanguageService } from './languageService'
-export type { DefinitionResult, CompletionInfoResponse, QuickInfoBody } from './languageService'
+export type { DefinitionResult, CompletionInfoResponse } from './languageService'
 export { TypeScriptServerProbe } from './probe'

--- a/src/typescript/language/probe.ts
+++ b/src/typescript/language/probe.ts
@@ -1,7 +1,6 @@
 import { injectable } from 'inversify'
 import * as vscode from 'vscode'
 import { Logger } from '@/logger'
-import { isJavaScriptFile } from '@/utils/isJavaScriptFile'
 import { TypeScriptLanguageService } from './languageService'
 
 const DEFAULT_TIMEOUT_MS = 10_000
@@ -90,33 +89,7 @@ export class TypeScriptServerProbe implements vscode.Disposable {
       return false
     }
 
-    if (definition.targetUri.scheme !== 'file') {
-      return true
-    }
-
-    if (isJavaScriptFile(definition.targetUri.fsPath)) {
-      this.logger.debug('probe: skipping quickinfo for JS target:', definition.targetUri.fsPath)
-      return true
-    }
-
-    try {
-      const body = await this.languageService.requestQuickInfo(
-        definition.targetUri.fsPath,
-        definition.targetRange.start.line + 1,
-        definition.targetRange.start.character + 1,
-      )
-
-      if (body?.kind) {
-        return true
-      }
-
-      this.logger.debug('probe: quickinfo returned empty body')
-      return false
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      this.logger.debug('probe: quickinfo error:', message)
-      return false
-    }
+    return true
   }
 
   private delay(ms: number, signal: AbortSignal) {


### PR DESCRIPTION
## Release

### 포함 커밋

- fix(probe): remove unnecessary quickinfo check from readiness probe (#97)
- fix(resolver): skip tsserver requests for JS definition targets (#94)
