### PR TITLE
feat(resolver): introduce SymbolConfidence for resolver result selection

### DIFF
--- a/src/decoration/resolver.ts
+++ b/src/decoration/resolver.ts
@@ -33,27 +33,22 @@ export class SymbolResolver {
     languageService: TypeScriptLanguageService,
   ) {
     this.resolvers = [
-      new PluginSymbolResolver(languageService),
-      new HoverSymbolResolver(languageService),
       new SemanticTokenSymbolResolver(languageService),
+      new HoverSymbolResolver(languageService),
+      new PluginSymbolResolver(languageService),
     ]
   }
 
   async resolve() {
     const symbolKinds = new Map<string, SymbolKind>()
+    const allSymbols = [...this.targets.keys()]
 
     for (const resolver of this.resolvers) {
-      const remaining = [...this.targets.keys()].filter((s) => !symbolKinds.has(s))
-      if (remaining.length === 0) {
-        continue
-      }
-
-      const resolved = await this.resolveSymbols(resolver, remaining)
-      for (const [symbol, kind] of resolved) {
-        symbolKinds.set(symbol, kind)
-      }
-
+      const resolved = await this.resolveSymbols(resolver, allSymbols)
       if (resolved.size > 0) {
+        for (const [symbol, kind] of resolved) {
+          symbolKinds.set(symbol, kind)
+        }
         this._onPhase.fire(symbolKinds)
       }
     }

--- a/src/decoration/resolver.ts
+++ b/src/decoration/resolver.ts
@@ -40,21 +40,16 @@ export class SymbolResolver {
   }
 
   async resolve() {
-    const symbolKinds = new Map<string, SymbolKind>()
     const allSymbols = [...this.targets.keys()]
 
     for (const resolver of this.resolvers) {
       const resolved = await this.resolveSymbols(resolver, allSymbols)
       if (resolved.size > 0) {
-        for (const [symbol, kind] of resolved) {
-          symbolKinds.set(symbol, kind)
-        }
-        this._onPhase.fire(symbolKinds)
+        this._onPhase.fire(resolved)
       }
     }
 
     this._onPhase.dispose()
-    return symbolKinds
   }
 
   private async resolveSymbols(resolver: BaseSymbolResolver, symbols: string[]) {

--- a/src/decoration/resolver.ts
+++ b/src/decoration/resolver.ts
@@ -24,8 +24,8 @@ export interface ResolveTarget {
 export class SymbolResolver {
   private readonly logger = Logger.create(SymbolResolver)
   private readonly resolvers: BaseSymbolResolver[]
-  private readonly _onPhase = new vscode.EventEmitter<Map<string, SymbolKind>>()
-  readonly onPhase = this._onPhase.event
+  private readonly _onResult = new vscode.EventEmitter<Map<string, SymbolKind>>()
+  readonly onResult = this._onResult.event
 
   constructor(
     private readonly document: vscode.TextDocument,
@@ -45,11 +45,11 @@ export class SymbolResolver {
     for (const resolver of this.resolvers) {
       const resolved = await this.resolveSymbols(resolver, allSymbols)
       if (resolved.size > 0) {
-        this._onPhase.fire(resolved)
+        this._onResult.fire(resolved)
       }
     }
 
-    this._onPhase.dispose()
+    this._onResult.dispose()
   }
 
   private async resolveSymbols(resolver: BaseSymbolResolver, symbols: string[]) {

--- a/src/decoration/service.test.ts
+++ b/src/decoration/service.test.ts
@@ -681,7 +681,7 @@ describe('DecorationService', () => {
         expect(cacheAfterFirst!.symbolKinds.get('useState')).toBe(SymbolKind.Class)
       })
 
-      it('should ignore stale onPhase events', async () => {
+      it('should ignore stale onResult events', async () => {
         vi.useRealTimers()
 
         mockParserReturn(service, [
@@ -710,7 +710,7 @@ describe('DecorationService', () => {
         const second = service.applyImportDecorations(editor)
         await second
 
-        // First resolver's onPhase fires — should be ignored
+        // First resolver's onResult fires — should be ignored
         vi.mocked(editor.setDecorations).mockClear()
         resolvePlugin(SymbolKind.Function)
         await first

--- a/src/decoration/service.ts
+++ b/src/decoration/service.ts
@@ -77,7 +77,7 @@ export class DecorationService implements vscode.Disposable {
 
     const isStale = () => this.activeResolvers.get(docUri) !== resolver
 
-    resolver.onPhase((phaseKinds) => {
+    resolver.onResult((phaseKinds) => {
       if (isStale()) {
         return
       }

--- a/src/decoration/service.ts
+++ b/src/decoration/service.ts
@@ -77,16 +77,20 @@ export class DecorationService implements vscode.Disposable {
 
     const isStale = () => this.activeResolvers.get(docUri) !== resolver
 
-    resolver.onPhase((phaseKinds) => {
-      if (isStale()) {
-        return
-      }
-      for (const [symbol, kind] of phaseKinds) {
+    const mergeByConfidence = (results: Map<string, SymbolKind>) => {
+      for (const [symbol, kind] of results) {
         const existing = symbolKinds.get(symbol)
         if (!existing || SymbolConfidence[kind] >= SymbolConfidence[existing]) {
           symbolKinds.set(symbol, kind)
         }
       }
+    }
+
+    resolver.onPhase((phaseKinds) => {
+      if (isStale()) {
+        return
+      }
+      mergeByConfidence(phaseKinds)
       this.applyDecorationsToEditor(editor, context.occurrences, symbolKinds)
     })
 
@@ -96,12 +100,7 @@ export class DecorationService implements vscode.Disposable {
       return
     }
 
-    for (const [symbol, kind] of resolved) {
-      const existing = symbolKinds.get(symbol)
-      if (!existing || SymbolConfidence[kind] >= SymbolConfidence[existing]) {
-        symbolKinds.set(symbol, kind)
-      }
-    }
+    mergeByConfidence(resolved)
 
     const unresolved = [...targetsToResolve.keys()].filter((s) => !symbolKinds.has(s))
     if (unresolved.length > 0) {

--- a/src/decoration/service.ts
+++ b/src/decoration/service.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode'
 import { TOKENS } from '@/di/tokens'
 import { Logger } from '@/logger'
 import { TypeScriptParser } from '@/parser'
-import type { SymbolKind } from '@/symbol'
+import { SymbolConfidence, type SymbolKind } from '@/symbol'
 import type { SymbolColorMap } from '@/theme'
 import { TypeScriptLanguageService, TypeScriptServerProbe } from '@/typescript/language'
 import type { ResolveTarget } from './resolver'
@@ -82,7 +82,10 @@ export class DecorationService implements vscode.Disposable {
         return
       }
       for (const [symbol, kind] of phaseKinds) {
-        symbolKinds.set(symbol, kind)
+        const existing = symbolKinds.get(symbol)
+        if (!existing || SymbolConfidence[kind] >= SymbolConfidence[existing]) {
+          symbolKinds.set(symbol, kind)
+        }
       }
       this.applyDecorationsToEditor(editor, context.occurrences, symbolKinds)
     })
@@ -94,7 +97,10 @@ export class DecorationService implements vscode.Disposable {
     }
 
     for (const [symbol, kind] of resolved) {
-      symbolKinds.set(symbol, kind)
+      const existing = symbolKinds.get(symbol)
+      if (!existing || SymbolConfidence[kind] >= SymbolConfidence[existing]) {
+        symbolKinds.set(symbol, kind)
+      }
     }
 
     const unresolved = [...targetsToResolve.keys()].filter((s) => !symbolKinds.has(s))

--- a/src/decoration/service.ts
+++ b/src/decoration/service.ts
@@ -77,20 +77,16 @@ export class DecorationService implements vscode.Disposable {
 
     const isStale = () => this.activeResolvers.get(docUri) !== resolver
 
-    const mergeByConfidence = (results: Map<string, SymbolKind>) => {
-      for (const [symbol, kind] of results) {
+    resolver.onPhase((phaseKinds) => {
+      if (isStale()) {
+        return
+      }
+      for (const [symbol, kind] of phaseKinds) {
         const existing = symbolKinds.get(symbol)
         if (!existing || SymbolConfidence[kind] >= SymbolConfidence[existing]) {
           symbolKinds.set(symbol, kind)
         }
       }
-    }
-
-    resolver.onPhase((phaseKinds) => {
-      if (isStale()) {
-        return
-      }
-      mergeByConfidence(phaseKinds)
       this.applyDecorationsToEditor(editor, context.occurrences, symbolKinds)
     })
 

--- a/src/decoration/service.ts
+++ b/src/decoration/service.ts
@@ -94,13 +94,11 @@ export class DecorationService implements vscode.Disposable {
       this.applyDecorationsToEditor(editor, context.occurrences, symbolKinds)
     })
 
-    const resolved = await resolver.resolve()
+    await resolver.resolve()
 
     if (isStale()) {
       return
     }
-
-    mergeByConfidence(resolved)
 
     const unresolved = [...targetsToResolve.keys()].filter((s) => !symbolKinds.has(s))
     if (unresolved.length > 0) {

--- a/src/symbol/index.ts
+++ b/src/symbol/index.ts
@@ -1,3 +1,3 @@
 export { TypeScriptServerNotLoadedError } from './errors'
 export { HoverSymbolResolver, PluginSymbolResolver, SemanticTokenSymbolResolver } from './resolvers'
-export { BaseSymbolResolver, SymbolKind } from './types'
+export { BaseSymbolResolver, SymbolConfidence, SymbolKind } from './types'

--- a/src/symbol/types.ts
+++ b/src/symbol/types.ts
@@ -14,6 +14,16 @@ export enum SymbolKind {
   Variable = 'variable',
 }
 
+export const SymbolConfidence: Record<SymbolKind, number> = {
+  [SymbolKind.Function]: 0.9,
+  [SymbolKind.Class]: 0.9,
+  [SymbolKind.Interface]: 0.8,
+  [SymbolKind.Type]: 0.8,
+  [SymbolKind.Enum]: 0.8,
+  [SymbolKind.Namespace]: 0.7,
+  [SymbolKind.Variable]: 0.5,
+}
+
 export abstract class BaseSymbolResolver {
   abstract readonly name: string
   protected readonly logger: Logger


### PR DESCRIPTION
## Summary
- `SymbolKind`별 confidence 값을 정의하는 `SymbolConfidence` 상수 도입
- Resolver 실행 순서를 낮은 confidence → 높은 confidence 순으로 변경 (`SemanticToken → Hover → Plugin`)하여 빠른 초기 decoration 제공
- 모든 resolver가 모든 symbol에 대해 실행되며, confidence가 더 높은 결과만 덮어쓰도록 변경
- `resolve()`가 결과를 반환하지 않도록 정리 — `onPhase` 이벤트가 유일한 결과 전달 채널

Closes #101

## Test plan
- [x] 기존 테스트 325개 전부 통과
- [x] 빌드 성공
- [ ] 실제 프로젝트에서 import decoration이 정상 동작하는지 확인
- [ ] variable로 잘못 잡히던 function이 올바르게 보정되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)